### PR TITLE
nan v1.8.4 for io.js v2.0.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "bindings": "1.2.x",
-    "nan": "1.7.x"
+    "nan": "~1.8.4"
   }
 }


### PR DESCRIPTION
This is a proposed fix for nan incompatibility with io.js v2.0.0 reported in #27
