### PR TITLE
chore: update clang-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "prebuild-install": "^2.1.0"
   },
   "devDependencies": {
-    "clang-format": "^1.0.38",
-    "standard": "^10.0.1",
+    "clang-format": "^1.0.41",
     "prebuild": "^6.1.0",
-    "prebuild-ci": "^2.2.3"
+    "prebuild-ci": "^2.2.3",
+    "standard": "^10.0.1"
   }
 }


### PR DESCRIPTION
The current version of clang format is breaking npm-3 for some reason
I can't get to the bottom of what is going on there, but simply
updating the dependency seems to fix the problem

Without this fix installing microtime for development is broken on v6.x