### PR TITLE
Upgrade dependencies & M1 Build Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       env: [TEST_CMD=lint-test]
     - os: osx
       node_js: node
-      env: [TEST_CMD=lint-test, BUILD_CMD=prebuild, BUILD_GROUP=darwin-x64]
+      env: [TEST_CMD=lint-test, BUILD_CMD=prebuild-darwin, BUILD_GROUP=darwin]
     - name: arm
       os: linux
       node_js: node

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,18 +5,29 @@
       'sources': [ 'src/microtime.cc' ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
-      'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
+      'include_dirs': ["<!(node -p \"require('node-addon-api').include_dir\")"],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
-      'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
       'conditions': [
-        ['OS=="mac"',
-          {
-            'xcode_settings': {
-              # https://github.com/nodejs/node/pull/23685#issuecomment-430408541
-              'MACOSX_DEPLOYMENT_TARGET': '10.9',
+        ["OS=='win'", {
+          "defines": [
+            "_HAS_EXCEPTIONS=1"
+          ],
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "ExceptionHandling": 1
             },
-          }
-        ]]
+          },
+        }],
+        ["OS=='mac'", {
+          'cflags+': ['-fvisibility=hidden'],
+          'xcode_settings': {
+            'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+          },
+        }],
+      ],
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,28 +13,28 @@
     "gettimeofday"
   ],
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 14.13.0"
   },
   "scripts": {
     "install": "node-gyp-build",
     "rebuild": "node-gyp rebuild",
-    "prebuild": "prebuildify -t 8.14.0 -t electron@3.0.0 --napi --strip",
+    "prebuild": "prebuildify -t 14.13.0 -t electron@18.2.0 --napi --strip",
     "download-prebuilds": "prebuildify-ci download",
-    "prebuildify-cross-armv7": "prebuildify-cross --platform=linux --arch=arm --arm-version=7 -- -t 8.14.0 --napi --strip",
+    "prebuildify-cross-armv7": "prebuildify-cross --platform=linux --arch=arm --arm-version=7 -- -t 14.13.0 --napi --strip",
     "test": "node test.js",
     "format": "clang-format -i src/microtime.cc",
     "lint-test": "standard && clang-format -output-replacements-xml src/microtime.cc | (! grep -q '<replacement ') && node test.js"
   },
   "dependencies": {
-    "node-addon-api": "^1.2.0",
-    "node-gyp-build": "^3.8.0"
+    "node-addon-api": "^5.0.0",
+    "node-gyp-build": "^4.4.0"
   },
   "devDependencies": {
-    "clang-format": "^1.2.4",
-    "node-gyp": "^3.8.0",
-    "prebuildify": "^2.11.0",
-    "prebuildify-ci": "^1.0.4",
-    "prebuildify-cross": "^3.1.2",
+    "clang-format": "^1.8.0",
+    "node-gyp": "^9.0.0",
+    "prebuildify": "^5.0.0",
+    "prebuildify-ci": "^1.0.5",
+    "prebuildify-cross": "^5.0.0",
     "standard": "^12.0.1"
   },
   "gypfile": true

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "install": "node-gyp-build",
     "rebuild": "node-gyp rebuild",
     "prebuild": "prebuildify -t 14.13.0 -t electron@18.2.0 --napi --strip",
+    "prebuild-darwin": "prebuildify -t 14.13.0 -t electron@18.2.0 --arch x64+arm64 --napi --strip",
     "download-prebuilds": "prebuildify-ci download",
     "prebuildify-cross-armv7": "prebuildify-cross --platform=linux --arch=arm --arm-version=7 -- -t 14.13.0 --napi --strip",
     "test": "node test.js",


### PR DESCRIPTION
- Updates build dependencies to latest. 
- Adds darwin universal prebuild to support M1 macs

Addresses https://github.com/wadey/node-microtime/issues/67

@wadey I took a stab updating this to support builds for M1 macs, but this is my first time touching a cpp node module. So would appreciate any help on this one. I am able to generate the builds for darwin-x64+arm64 on my local machine, but I'm not sure what updates need to be made to the travis script if any. For now I just created a darwin specific script to generate the universal builds just on macos.